### PR TITLE
Update composer.json database migrations path

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     },
     "autoload": {
         "classmap": [
-            "src/database"
+            "database/migrations"
         ],
         "psr-4": {
             "Mage2\\Feature\\": "src/"


### PR DESCRIPTION
I got error on fresh install mage e-commerce, turns out the path needs to be fixed (also applies to a bunch of other modules). Or am I missing something here ?

Thanks 